### PR TITLE
[BPK-1257] Add Android support

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -34,4 +34,12 @@ module.exports = {
       /from 'bpk-/g,
     ],
   },
+  android: {
+    globs: [
+      '**/*.{java,kt,xml}',
+    ],
+    patterns: [
+      /bpk/g,
+    ],
+  },
 };


### PR DESCRIPTION
Spoke to @matteo-hertel about the best thing to use for `patterns`. 

He reckons, for now, we should just use `/bpk/g`, as it'll catch:

**XML**
```
<TextView android:textColor="@color/bpkGreen500" />
<item name="colorPrimary">@color/bpkBlue500</item>
```

**Java / Kotlin**
```
assertEquals("#ff00b2d6", appContext.getResources().getString(R.color.bpkBlue500));
```

We may be able to refine it over time but it should be good for now.

I used it on the `/app` folder in `backpack-android` and got:

```
Number of files analysed: 12
Number of Backpack usages: 3
Usage (%): 25.00
```

..which matches what a manual search yielded.